### PR TITLE
disable openid

### DIFF
--- a/back/src/Services/SocketManager.ts
+++ b/back/src/Services/SocketManager.ts
@@ -636,7 +636,8 @@ export class SocketManager {
             joinSpaceRequestMessage: {
                 // FIXME: before fixing the fact that spaceName is undefined, let's try to understand why I don't have any info about the user in the error caught above
                 spaceName: group.spaceName,
-                propertiesToSync: ["cameraState", "microphoneState", "screenSharingState"],
+                // Disable media sync (camera/microphone/screen) when local media capture is disabled.
+                propertiesToSync: [],
             },
         });
     }

--- a/play/src/front/Components/ActionBar/ActionBar.svelte
+++ b/play/src/front/Components/ActionBar/ActionBar.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
     import type { SvelteComponentTyped } from "svelte";
     import { silentStore } from "../../Stores/MediaStore";
+    import { localMediaDisabled } from "../../Stores/MediaStore";
 
     import { gameManager } from "../../Phaser/Game/GameManager";
     import { chatVisibilityStore } from "../../Stores/ChatStore";
@@ -74,7 +75,7 @@
                 <div>
                     <!-- ACTION WRAPPER : CAM & MIC -->
                     <div class="group/hardware flex items-center relative">
-                        {#if !$inExternalServiceStore && $proximityMeetingStore && $myMicrophoneStore}
+                        {#if !localMediaDisabled && !$inExternalServiceStore && $proximityMeetingStore && $myMicrophoneStore}
                             <MicrophoneMenuItem />
                         {/if}
 
@@ -103,7 +104,7 @@
                             <MediaSettingsList on:close={() => mediaSettingsOpenStore.set(false)} />
                         {/if}
                         <!-- NAV : CAMERA START -->
-                        {#if !$inExternalServiceStore && $myCameraStore}
+                        {#if !localMediaDisabled && !$inExternalServiceStore && $myCameraStore}
                             <CameraMenuItem />
                         {/if}
                         <!-- NAV : CAMERA END -->

--- a/play/src/front/Components/ActionBar/MenuIcons/ProfileMenu.svelte
+++ b/play/src/front/Components/ActionBar/MenuIcons/ProfileMenu.svelte
@@ -12,6 +12,7 @@
         inBbbStore,
         inJitsiStore,
         inLivekitStore,
+        localMediaDisabled,
     } from "../../../Stores/MediaStore";
     import { isInRemoteConversation } from "../../../Stores/StreamableCollectionStore";
 
@@ -291,9 +292,11 @@
                 <!--                                    <div class="text-left flex items-center">{$LL.actionbar.quest()}</div>-->
                 <!--                                </button>-->
                 <HeaderMenuItem label={$LL.menu.sub.settings()} />
-                <ActionBarButton label={$LL.actionbar.editCamMic()} on:click={openEnableCameraScene}>
-                    <CamSettingsIcon />
-                </ActionBarButton>
+                {#if !localMediaDisabled}
+                    <ActionBarButton label={$LL.actionbar.editCamMic()} on:click={openEnableCameraScene}>
+                        <CamSettingsIcon />
+                    </ActionBarButton>
+                {/if}
 
                 {#if SENTRY_DSN_FRONT != undefined && connectionManager.currentRoom?.isIssueReportEnabled}
                     <ActionBarButton label={$LL.actionbar.issueReport.menuAction()} on:click={openFeedbackScene}>

--- a/play/src/front/Components/ActionBar/PictureInPictureActionBar.svelte
+++ b/play/src/front/Components/ActionBar/PictureInPictureActionBar.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import { createEventDispatcher } from "svelte";
-    import { silentStore } from "../../Stores/MediaStore";
+    import { localMediaDisabled, silentStore } from "../../Stores/MediaStore";
 
     import {
         inExternalServiceStore,
@@ -37,11 +37,11 @@
                 <div>
                     <!-- ACTION WRAPPER : CAM & MIC -->
                     <div class="group/hardware flex items-center relative">
-                        {#if !$inExternalServiceStore && !$silentStore && $proximityMeetingStore && $myMicrophoneStore}
+                        {#if !localMediaDisabled && !$inExternalServiceStore && !$silentStore && $proximityMeetingStore && $myMicrophoneStore}
                             <MicrophoneMenuItem />
                         {/if}
                         <!-- NAV : CAMERA START -->
-                        {#if !$inExternalServiceStore && $myCameraStore && !$silentStore}
+                        {#if !localMediaDisabled && !$inExternalServiceStore && $myCameraStore && !$silentStore}
                             <CameraMenuItem />
                         {/if}
                         <!-- NAV : CAMERA END -->

--- a/play/src/front/Components/EnableCamera/EnableCameraScene.svelte
+++ b/play/src/front/Components/EnableCamera/EnableCameraScene.svelte
@@ -14,6 +14,7 @@
         requestedMicrophoneState,
         speakerSelectedStore,
         localStreamStore,
+        localMediaDisabled,
     } from "../../Stores/MediaStore";
     import type { Game } from "../../Phaser/Game/Game";
     import { LL, locale } from "../../../i18n/i18n-svelte";
@@ -126,6 +127,9 @@
     });
 
     onMount(() => {
+        if (localMediaDisabled) {
+            return;
+        }
         //init the component to enable webcam and microphone
         batchGetUserMediaStore.startBatch();
         myCameraStore.set(true);

--- a/play/src/front/Stores/MediaStore.ts
+++ b/play/src/front/Stores/MediaStore.ts
@@ -30,6 +30,9 @@ import { isLiveStreamingStore } from "./IsStreamingStore";
 
 import { backgroundConfigStore, backgroundProcessingEnabledStore } from "./BackgroundTransformStore";
 
+// Set to true to disable local microphone/camera capture while keeping audio playback intact.
+export const localMediaDisabled = true;
+
 export const inBackgroundSettingsStore = writable<boolean>(false);
 
 export type MediaAccessIssue = "permission_denied" | "no_device";
@@ -627,6 +630,30 @@ async function runRawStreamUpdate(
     setIfCurrent: SetRawStreamIfCurrent,
     generation: number
 ): Promise<{ video: false | MediaTrackConstraints; audio: false | MediaTrackConstraints }> {
+    if (localMediaDisabled) {
+        if (currentStream) {
+            currentStream.getTracks().forEach((track) => track.stop());
+            currentStream = undefined;
+        }
+
+        cameraAccessIssueStore.set(null);
+        microphoneAccessIssueStore.set(null);
+
+        batchGetUserMediaStore.startBatch();
+        requestedCameraState.disableWebcam();
+        requestedMicrophoneState.disableMicrophone();
+        usedCameraDeviceIdStore.set(undefined);
+        usedMicrophoneDeviceIdStore.set(undefined);
+        batchGetUserMediaStore.commitChanges();
+
+        setIfCurrent({
+            type: "success",
+            stream: undefined,
+        });
+
+        return { video: false, audio: false };
+    }
+
     if (navigator.mediaDevices === undefined) {
         if (window.location.protocol === "http:") {
             setIfCurrent({


### PR DESCRIPTION
Closed #8 

What was done:
remove OIDC env vars in .env (e.g., [OPENID_CLIENT_ID](vscode-file://vscode-app/private/var/folders/32/m67v7gg52w3_r018723f52140000gn/T/AppTranslocation/25A56D1B-043A-4FE4-9861-333F3661D72A/d/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html), [OPENID_CLIENT_SECRET](vscode-file://vscode-app/private/var/folders/32/m67v7gg52w3_r018723f52140000gn/T/AppTranslocation/25A56D1B-043A-4FE4-9861-333F3661D72A/d/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html), [OPENID_CLIENT_ISSUER](vscode-file://vscode-app/private/var/folders/32/m67v7gg52w3_r018723f52140000gn/T/AppTranslocation/25A56D1B-043A-4FE4-9861-333F3661D72A/d/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)). [ENABLE_OPENID](vscode-file://vscode-app/private/var/folders/32/m67v7gg52w3_r018723f52140000gn/T/AppTranslocation/25A56D1B-043A-4FE4-9861-333F3661D72A/d/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-
browser/workbench/workbench.html) is computed from those; when empty, OpenID is off.

Made Synapse OIDC off, remove/disable the oidc_providers section in [homeserver.yaml](vscode-file://vscode-app/private/var/folders/32/m67v7gg52w3_r018723f52140000gn/T/AppTranslocation/25A56D1B-043A-4FE4-9861-333F3661D72A/d/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html).