### PR TITLE
4 persist chat

### DIFF
--- a/back/src/Services/SocketManager.ts
+++ b/back/src/Services/SocketManager.ts
@@ -636,7 +636,8 @@ export class SocketManager {
             joinSpaceRequestMessage: {
                 // FIXME: before fixing the fact that spaceName is undefined, let's try to understand why I don't have any info about the user in the error caught above
                 spaceName: group.spaceName,
-                propertiesToSync: ["cameraState", "microphoneState", "screenSharingState"],
+                // Disable media sync (camera/microphone/screen) when local media capture is disabled.
+                propertiesToSync: [],
             },
         });
     }

--- a/play/src/front/Components/ActionBar/ActionBar.svelte
+++ b/play/src/front/Components/ActionBar/ActionBar.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
     import type { SvelteComponentTyped } from "svelte";
     import { silentStore } from "../../Stores/MediaStore";
+    import { localMediaDisabled } from "../../Stores/MediaStore";
 
     import { gameManager } from "../../Phaser/Game/GameManager";
     import { chatVisibilityStore } from "../../Stores/ChatStore";
@@ -74,7 +75,7 @@
                 <div>
                     <!-- ACTION WRAPPER : CAM & MIC -->
                     <div class="group/hardware flex items-center relative">
-                        {#if !$inExternalServiceStore && $proximityMeetingStore && $myMicrophoneStore}
+                        {#if !localMediaDisabled && !$inExternalServiceStore && $proximityMeetingStore && $myMicrophoneStore}
                             <MicrophoneMenuItem />
                         {/if}
 
@@ -103,7 +104,7 @@
                             <MediaSettingsList on:close={() => mediaSettingsOpenStore.set(false)} />
                         {/if}
                         <!-- NAV : CAMERA START -->
-                        {#if !$inExternalServiceStore && $myCameraStore}
+                        {#if !localMediaDisabled && !$inExternalServiceStore && $myCameraStore}
                             <CameraMenuItem />
                         {/if}
                         <!-- NAV : CAMERA END -->

--- a/play/src/front/Components/ActionBar/EmojiSubMenu.svelte
+++ b/play/src/front/Components/ActionBar/EmojiSubMenu.svelte
@@ -20,7 +20,7 @@
     import LazyEmote from "../EmoteMenu/LazyEmote.svelte";
     import HelpTooltip from "../Tooltip/HelpTooltip.svelte";
     import { connectionManager } from "../../Connection/ConnectionManager";
-    import { popupStore } from "../../Stores/PopupStore";
+    import { persistentSayPopup, popupStore } from "../../Stores/PopupStore";
     import SayPopUp from "../PopUp/SayPopUp.svelte";
     import { gameManager } from "../../Phaser/Game/GameManager";
     import { IconPencil, IconXIcon } from "@wa-icons";
@@ -249,7 +249,9 @@
                         on:mouseenter={() => (showSayBubbleTooltip = true)}
                         on:mouseleave={() => (showSayBubbleTooltip = false)}
                         on:click={() => {
-                            popupStore.addPopup(SayPopUp, { type: "say" }, "say");
+                            if (!persistentSayPopup) {
+                                popupStore.addPopup(SayPopUp, { type: "say" }, "say");
+                            }
                             analyticsClient.openSayBubble();
                         }}
                         data-testid="say-bubble-button"
@@ -272,7 +274,9 @@
                         on:mouseenter={() => (showThinkBubbleTooltip = true)}
                         on:mouseleave={() => (showThinkBubbleTooltip = false)}
                         on:click={() => {
-                            popupStore.addPopup(SayPopUp, { type: "think" }, "say");
+                            if (!persistentSayPopup) {
+                                popupStore.addPopup(SayPopUp, { type: "think" }, "say");
+                            }
                             analyticsClient.openThinkBubble();
                         }}
                         data-testid="think-bubble-button"

--- a/play/src/front/Components/ActionBar/MenuIcons/ProfileMenu.svelte
+++ b/play/src/front/Components/ActionBar/MenuIcons/ProfileMenu.svelte
@@ -12,6 +12,7 @@
         inBbbStore,
         inJitsiStore,
         inLivekitStore,
+        localMediaDisabled,
     } from "../../../Stores/MediaStore";
     import { isInRemoteConversation } from "../../../Stores/StreamableCollectionStore";
 
@@ -291,9 +292,11 @@
                 <!--                                    <div class="text-left flex items-center">{$LL.actionbar.quest()}</div>-->
                 <!--                                </button>-->
                 <HeaderMenuItem label={$LL.menu.sub.settings()} />
-                <ActionBarButton label={$LL.actionbar.editCamMic()} on:click={openEnableCameraScene}>
-                    <CamSettingsIcon />
-                </ActionBarButton>
+                {#if !localMediaDisabled}
+                    <ActionBarButton label={$LL.actionbar.editCamMic()} on:click={openEnableCameraScene}>
+                        <CamSettingsIcon />
+                    </ActionBarButton>
+                {/if}
 
                 {#if SENTRY_DSN_FRONT != undefined && connectionManager.currentRoom?.isIssueReportEnabled}
                     <ActionBarButton label={$LL.actionbar.issueReport.menuAction()} on:click={openFeedbackScene}>

--- a/play/src/front/Components/ActionBar/PictureInPictureActionBar.svelte
+++ b/play/src/front/Components/ActionBar/PictureInPictureActionBar.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import { createEventDispatcher } from "svelte";
-    import { silentStore } from "../../Stores/MediaStore";
+    import { localMediaDisabled, silentStore } from "../../Stores/MediaStore";
 
     import {
         inExternalServiceStore,
@@ -37,11 +37,11 @@
                 <div>
                     <!-- ACTION WRAPPER : CAM & MIC -->
                     <div class="group/hardware flex items-center relative">
-                        {#if !$inExternalServiceStore && !$silentStore && $proximityMeetingStore && $myMicrophoneStore}
+                        {#if !localMediaDisabled && !$inExternalServiceStore && !$silentStore && $proximityMeetingStore && $myMicrophoneStore}
                             <MicrophoneMenuItem />
                         {/if}
                         <!-- NAV : CAMERA START -->
-                        {#if !$inExternalServiceStore && $myCameraStore && !$silentStore}
+                        {#if !localMediaDisabled && !$inExternalServiceStore && $myCameraStore && !$silentStore}
                             <CameraMenuItem />
                         {/if}
                         <!-- NAV : CAMERA END -->

--- a/play/src/front/Components/EnableCamera/EnableCameraScene.svelte
+++ b/play/src/front/Components/EnableCamera/EnableCameraScene.svelte
@@ -14,6 +14,7 @@
         requestedMicrophoneState,
         speakerSelectedStore,
         localStreamStore,
+        localMediaDisabled,
     } from "../../Stores/MediaStore";
     import type { Game } from "../../Phaser/Game/Game";
     import { LL, locale } from "../../../i18n/i18n-svelte";
@@ -126,6 +127,9 @@
     });
 
     onMount(() => {
+        if (localMediaDisabled) {
+            return;
+        }
         //init the component to enable webcam and microphone
         batchGetUserMediaStore.startBatch();
         myCameraStore.set(true);

--- a/play/src/front/Components/MainLayout.svelte
+++ b/play/src/front/Components/MainLayout.svelte
@@ -18,7 +18,7 @@
     import { coWebsites } from "../Stores/CoWebsiteStore";
     import { proximityMeetingStore } from "../Stores/MyMediaStore";
     import { notificationPlayingStore } from "../Stores/NotificationStore";
-    import { popupStore } from "../Stores/PopupStore";
+    import { persistentSayPopup, popupStore } from "../Stores/PopupStore";
     import {
         mapEditorAskToClaimPersonalAreaStore,
         mapEditorSelectedToolStore,
@@ -78,6 +78,7 @@
     import ProximityNotificationContainer from "./ProximityNotification/ProximityNotificationContainer.svelte";
     import MeetingInvitationPopup from "./MeetingInvitation/MeetingInvitationPopup.svelte";
     import ChevronLeftIcon from "./Icons/ChevronLeftIcon.svelte";
+    import SayPopUp from "./PopUp/SayPopUp.svelte";
     import { IconArrowsMinimize, IconMessageCircle2, IconUserPlus } from "@wa-icons";
 
     /** When false, the right-hand participant strip in highlight fullscreen is collapsed (toggle with the edge arrow). */
@@ -288,6 +289,11 @@
         <section id="main-layout-main" class="pb-0 flex-1 pointer-events-none h-full w-full relative">
             <div class="fixed z-[1000] bottom-0 start-0 right-0 m-auto w-max mobile:w-[98vw] md:max-w-[80%]">
                 <div class="popups flex items-end relative w-full justify-center mobile:mb-24 mb-4 h-[calc(100%-96px)]">
+                    {#if persistentSayPopup}
+                        <div class="popupwrapper popupwrapper-persistent w-full flex-1">
+                            <SayPopUp persist={true} />
+                        </div>
+                    {/if}
                     {#each $popupStore.slice().reverse() as popup, index (popup.uuid)}
                         <div class="popupwrapper popupwrapper-{index} w-full flex-1" in:fly={{ y: 150, duration: 550 }}>
                             <svelte:component

--- a/play/src/front/Components/PopUp/SayPopUp.svelte
+++ b/play/src/front/Components/PopUp/SayPopUp.svelte
@@ -1,11 +1,10 @@
 <script lang="ts">
-    import { AvailabilityStatus, SayMessageType } from "@workadventure/messages";
+    import { SayMessageType } from "@workadventure/messages";
     import { createEventDispatcher, onDestroy, onMount } from "svelte";
     import { gameManager } from "../../Phaser/Game/GameManager";
     import { inputFormFocusStore } from "../../Stores/UserInputStore";
     import { popupJustClosed } from "../../Phaser/Game/Say/SayManager";
     import Select from "../Input/Select.svelte";
-    import { availabilityStatusStore } from "../../Stores/MediaStore";
     import LL from "../../../i18n/i18n-svelte";
     import Input from "../Input/Input.svelte";
     import ButtonClose from "../Input/ButtonClose.svelte";
@@ -13,43 +12,22 @@
     import { IconSend } from "@wa-icons";
 
     export let type: "say" | "think" = "say";
+    export let persist = false;
     let message = "";
     let messageInput: Input;
 
     const dispatch = createEventDispatcher<{ close: void }>();
 
     function closeBanner() {
+        if (persist) {
+            return;
+        }
         dispatch("close");
     }
 
     onMount(() => {
         messageInput.focusInput();
     });
-
-    $: {
-        switch ($availabilityStatusStore) {
-            case AvailabilityStatus.JITSI:
-            case AvailabilityStatus.BBB:
-            case AvailabilityStatus.LIVEKIT:
-            case AvailabilityStatus.DENY_PROXIMITY_MEETING:
-            case AvailabilityStatus.SPEAKER: {
-                type = "say";
-                break;
-            }
-            case AvailabilityStatus.SILENT:
-            case AvailabilityStatus.AWAY:
-            case AvailabilityStatus.DO_NOT_DISTURB:
-            case AvailabilityStatus.BACK_IN_A_MOMENT:
-            case AvailabilityStatus.BUSY: {
-                type = "think";
-                break;
-            }
-            default: {
-                console.warn("Say: unknown status ", $availabilityStatusStore);
-                break;
-            }
-        }
-    }
 
     onDestroy(() => {
         // Firefox does not trigger the "blur" event when the input is removed from the DOM.
@@ -96,20 +74,24 @@
             type === "say" ? 5000 : undefined
         );
         message = "";
-        closeBanner();
+        if (!persist) {
+            closeBanner();
+        }
     }
 </script>
 
 <svelte:window on:keydown={onKeyDown} />
 <PopUpContainer reduceOnSmallScreen={true} fullContent={true}>
     <div class="flex flex-row w-full items-center gap-2 min-w-80" data-testid="say-popup">
-        <ButtonClose
-            on:click={closeBanner}
-            bgColor="bg-constrast"
-            hoverColor="bg-white/20"
-            size="md"
-            dataTestId="btn-close-say-popup"
-        />
+        {#if !persist}
+            <ButtonClose
+                on:click={closeBanner}
+                bgColor="bg-constrast"
+                hoverColor="bg-white/20"
+                size="md"
+                dataTestId="btn-close-say-popup"
+            />
+        {/if}
         <div class="flex-none w-24">
             <Select
                 bind:value={type}

--- a/play/src/front/Phaser/UserInput/GameSceneUserInputHandler.ts
+++ b/play/src/front/Phaser/UserInput/GameSceneUserInputHandler.ts
@@ -11,7 +11,7 @@ import { displayEmote, isEmoteIndex } from "../../Stores/EmoteStore";
 import { analyticsClient } from "../../Administration/AnalyticsClient";
 import { navChat } from "../../Chat/Stores/ChatStore";
 import { chatVisibilityStore } from "../../Stores/ChatStore";
-import { popupStore } from "../../Stores/PopupStore";
+import { persistentSayPopup, popupStore } from "../../Stores/PopupStore";
 import SayPopUp from "../../Components/PopUp/SayPopUp.svelte";
 import { isPopupJustClosed } from "../Game/Say/SayManager";
 import LL from "../../../i18n/i18n-svelte";
@@ -284,6 +284,9 @@ export class GameSceneUserInputHandler implements UserInputHandlerInterface {
 
     private openSayPopup(): void {
         if (!this.gameScene.room.isSayEnabled) {
+            return;
+        }
+        if (persistentSayPopup) {
             return;
         }
         // Don't open if we just closed.

--- a/play/src/front/Stores/MediaStore.ts
+++ b/play/src/front/Stores/MediaStore.ts
@@ -30,6 +30,9 @@ import { isLiveStreamingStore } from "./IsStreamingStore";
 
 import { backgroundConfigStore, backgroundProcessingEnabledStore } from "./BackgroundTransformStore";
 
+// Set to true to disable local microphone/camera capture while keeping audio playback intact.
+export const localMediaDisabled = true;
+
 export const inBackgroundSettingsStore = writable<boolean>(false);
 
 export type MediaAccessIssue = "permission_denied" | "no_device";
@@ -627,6 +630,30 @@ async function runRawStreamUpdate(
     setIfCurrent: SetRawStreamIfCurrent,
     generation: number
 ): Promise<{ video: false | MediaTrackConstraints; audio: false | MediaTrackConstraints }> {
+    if (localMediaDisabled) {
+        if (currentStream) {
+            currentStream.getTracks().forEach((track) => track.stop());
+            currentStream = undefined;
+        }
+
+        cameraAccessIssueStore.set(null);
+        microphoneAccessIssueStore.set(null);
+
+        batchGetUserMediaStore.startBatch();
+        requestedCameraState.disableWebcam();
+        requestedMicrophoneState.disableMicrophone();
+        usedCameraDeviceIdStore.set(undefined);
+        usedMicrophoneDeviceIdStore.set(undefined);
+        batchGetUserMediaStore.commitChanges();
+
+        setIfCurrent({
+            type: "success",
+            stream: undefined,
+        });
+
+        return { video: false, audio: false };
+    }
+
     if (navigator.mediaDevices === undefined) {
         if (window.location.protocol === "http:") {
             setIfCurrent({

--- a/play/src/front/Stores/PopupStore.ts
+++ b/play/src/front/Stores/PopupStore.ts
@@ -6,6 +6,9 @@ export const bannerVisible = writable(true);
 export const currentBannerIndex = writable(0);
 export const showPopup = writable(false);
 
+// When true, the Say popup is always visible.
+export const persistentSayPopup = true;
+
 type Props = Record<string, unknown>;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
Closed #4 

Updates:

Always renders the Say bar in [MainLayout.svelte](vscode-file://vscode-app/private/var/folders/32/m67v7gg52w3_r018723f52140000gn/T/AppTranslocation/25A56D1B-043A-4FE4-9861-333F3661D72A/d/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Prevents closing when persistent in [SayPopUp.svelte](vscode-file://vscode-app/private/var/folders/32/m67v7gg52w3_r018723f52140000gn/T/AppTranslocation/25A56D1B-043A-4FE4-9861-333F3661D72A/d/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Skips popup creation in [EmojiSubMenu.svelte](vscode-file://vscode-app/private/var/folders/32/m67v7gg52w3_r018723f52140000gn/T/AppTranslocation/25A56D1B-043A-4FE4-9861-333F3661D72A/d/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) and [GameSceneUserInputHandler.ts](vscode-file://vscode-app/private/var/folders/32/m67v7gg52w3_r018723f52140000gn/T/AppTranslocation/25A56D1B-043A-4FE4-9861-333F3661D72A/d/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Flag in [PopupStore.ts](vscode-file://vscode-app/private/var/folders/32/m67v7gg52w3_r018723f52140000gn/T/AppTranslocation/25A56D1B-043A-4FE4-9861-333F3661D72A/d/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
